### PR TITLE
Refactor: Removed commented code and added more documentation

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -13,11 +13,6 @@ import (
 
 var (
 	device string
-	// snapshot_len int32 = 1024
-	// promiscuous  bool  = false
-	// err          error
-	// timeout      pcap.BlockForever
-	// handle    *pcap.Handle
 	domainMap  map[string]int
 	lock       sync.Mutex
 	malwareMap map[string]int
@@ -55,38 +50,3 @@ func main() {
 	})
 	r.Run(":8880")
 }
-
-// func captureDNSPcts(device string) {
-// 	// Capturing live packets using pcap
-// 	handle, err = pcap.OpenLive(device, snapshot_len, promiscuous, pcap.BlockForever)
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	defer handle.Close()
-
-// 	//capture only dsn packets
-// 	if err := handle.SetBPFFilter("port 53"); err != nil {
-// 		log.Fatal(err)
-// 	}
-
-// 	// https://pkg.go.dev/github.com/google/gopacket#hdr-Reading_Packets_From_A_Source
-// 	// handle.LinkType hanles the interface type like ethernet /wifi
-// 	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
-// 	fmt.Println(packetSource)
-
-// 	for packet := range packetSource.Packets() {
-// 		dnsLayer := packet.Layer(layers.LayerTypeDNS)
-// 		if dnsLayer != nil {
-// 			dns := dnsLayer.(*layers.DNS)
-// 			for _, query := range dns.Questions {
-// 				domainName := string(query.Name)
-// 				// recordType := int(query.Type)
-// 				fmt.Println(domainName)
-// 				lock.Lock()
-// 				// domainName = domainName + "," + string(recordType)
-// 				domainMap[domainName]++
-// 				lock.Unlock()
-// 			}
-// 		}
-// 	}
-// }


### PR DESCRIPTION
In this pull request, I have removed all commented code from `src/main.go`, since it was moved to `utils` package.  
Additionally, I have added more documentation for all functions in `utils` package. With this changes code will become a bit cleaner, and even more easier to understand.